### PR TITLE
Fixes about cluster merging and XrtLaunchOp's sbp

### DIFF
--- a/python/oneflow_xrt/module.py
+++ b/python/oneflow_xrt/module.py
@@ -87,7 +87,7 @@ class XRTModule(flow.nn.Module):
         cluster_minimum_nodes=1,
         cluster_maximum_nodes=None,
         cluster_ignore_pipeline=True,
-        cluster_max_iteration=20,
+        cluster_max_iteration=100,
         dump_subgraph_dir=None,
         verbose=False,
     ):


### PR DESCRIPTION
- Change cluster_max_iteration default to 100, because 20 iteration maybe not enough for fully cluster merging in large model.
- Skip tick input's manipulating in XrtLaunchOp InferNdSbp function, because tick input will be manipulated in base class (UserOp) after this custom InferNdSbp function call. see: https://github.com/Oneflow-Inc/oneflow/blob/2d8520540413c0e745c0367b1bffa6845becece9/oneflow/core/operator/user_op.cpp#L984-L993