### PR TITLE
Fix xrt_launch_op unexpected ctrl in op name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ option(AUTO_INSTALL_ONEFLOW "Option to install oneflow automatically with pip" O
 
 project(oneflow-xrt CXX)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)

--- a/oneflow_xrt/compiler/passes/rebuild_job_pass.cpp
+++ b/oneflow_xrt/compiler/passes/rebuild_job_pass.cpp
@@ -343,13 +343,12 @@ void FoldSubgraphBuilder::FixupControlInOpNames() {
 
   for (const XrtNode* node : graph_->Nodes()) {
     auto* op_conf = CHECK_JUST(builder_->MutableOpConf4OpName(node->name()));
-    if (!node->sub_graph()) {
-      auto ctrl_in_op_names = op_conf->ctrl_in_op_name();
-      op_conf->clear_ctrl_in_op_name();
-      for (const auto& op_name : ctrl_in_op_names) {
-        AddControlInOpName(op_conf, op_name);
-      }
-    } else {
+    auto ctrl_in_op_names = op_conf->ctrl_in_op_name();
+    op_conf->clear_ctrl_in_op_name();
+    for (const auto& op_name : ctrl_in_op_names) {
+      AddControlInOpName(op_conf, op_name);
+    }
+    if (node->sub_graph()) {
       for (const XrtNode* sub_node : node->sub_graph()->Nodes()) {
         if (sub_node->IsEntryNode() || sub_node->IsReturnNode()) {
           continue;


### PR DESCRIPTION
- clear ctrl in from folded nodes for xrt launch op itself
- upgrade cxx standard to 17, since some included oneflow headers use std::string_view which is only supported after c++17